### PR TITLE
chore: fix README license badge — MIT → Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # AirAccountSmsAdapter
 
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 We will need many adapters, the first is SMS adapter using SIM800/SIM900a chips as adapter.
 To get SMS and parse into instructions, invoke the SDK of sim800 with instructions.
 
@@ -15,3 +16,7 @@ OK !
 **Only works for raspberrypi**
 
 > See cmd/bash.sh
+
+## License
+
+Licensed under the [Apache License, Version 2.0](https://opensource.org/licenses/Apache-2.0). See [LICENSE](./LICENSE) for details.


### PR DESCRIPTION
## Summary
- Fix incorrect MIT license references in README (actual LICENSE is Apache 2.0)
- Add Apache 2.0 badge where missing
- Add license section where missing

Automated fix via `scripts/fix-readme-license.sh`